### PR TITLE
Breaks needed to fix gcc3.4+ error

### DIFF
--- a/C Library/pifdec.c
+++ b/C Library/pifdec.c
@@ -652,6 +652,7 @@ uint32_t convertColor(uint32_t color, pifImageType sourceType, pifImageType targ
 					break;
 				default:
 					// Nothing to do
+					break;
 			}
 			break;
 		case PIF_TYPE_RGB565:
@@ -681,6 +682,7 @@ uint32_t convertColor(uint32_t color, pifImageType sourceType, pifImageType targ
 					break;
 				default:
 					// Nothing to do
+					break;
 			}
 			break;
 		case PIF_TYPE_RGB332:
@@ -701,6 +703,7 @@ uint32_t convertColor(uint32_t color, pifImageType sourceType, pifImageType targ
 					break;
 				default:
 					// Nothing to do
+					break;
 			}
 			break;
 		default:


### PR DESCRIPTION
Getting compiling error: "label at end of compound statement".

It is the problem about the compiler gcc3.4, which reports an error on default without statements, and it is warning on gcc3.3